### PR TITLE
AL-128: Replace StringTable where feasible

### DIFF
--- a/assemblyline_service_client/task_handler.py
+++ b/assemblyline_service_client/task_handler.py
@@ -1,33 +1,32 @@
 import copy
 import json
 import os
+import requests
 import select
 import shutil
 import signal
 import tempfile
 import time
+import yaml
+from enum import Enum
 from json import JSONDecodeError
 from typing import Optional
 
-import requests
-import yaml
-
 from assemblyline.common.digests import get_sha256_for_file
-from assemblyline.common.str_utils import StringTable
 from assemblyline.odm.messages.task import Task as ServiceTask
 from assemblyline.odm.models.service import Service
 from assemblyline_core.server_base import ServerBase
 
-STATUSES = StringTable('STATUSES', [
-    ('INITIALIZING', 0),
-    ('WAITING_FOR_TASK', 1),
-    ('DOWNLOADING_FILE', 2),
-    ('DOWNLOADING_FILE_COMPLETED', 3),
-    ('PROCESSING', 4),
-    ('RESULT_FOUND', 5),
-    ('ERROR_FOUND', 6),
-    ('STOPPING', 7),
-])
+
+class STATUSES(Enum):
+    INITIALIZING = 0
+    WAITING_FOR_TASK = 1
+    DOWNLOADING_FILE = 2
+    DOWNLOADING_FILE_COMPLETED = 3
+    PROCESSING = 4
+    RESULT_FOUND = 5
+    ERROR_FOUND = 6
+    STOPPING = 7
 
 SHUTDOWN_SECONDS_LIMIT = 10
 DEFAULT_API_KEY = 'ThisIsARandomAuthKey...ChangeMe!'


### PR DESCRIPTION
 - Creates STATUSES Enum

Relates to PRs in assemblyline-service-client and assembyline-base.

This PR intends to replace the StringTable implementation of STATUSES with a Python 3 Enum.