### PR TITLE
Call stop() function when TASK LIMIT is reached

### DIFF
--- a/assemblyline_service_client/task_handler.py
+++ b/assemblyline_service_client/task_handler.py
@@ -225,7 +225,11 @@ class TaskHandler(ServerBase):
     def try_run(self):
         self.initialize_service()
 
-        while self.running and self.tasks_processed < TASK_COMPLETE_LIMIT:
+        while self.running:
+            if self.tasks_processed >= TASK_COMPLETE_LIMIT:
+                self.stop()
+                return
+
             self.task = self.get_task()
             if not self.task:
                 continue


### PR DESCRIPTION
This should fix Issue #24 by calling the close function when the max number of task is reached therefor properly closing the pipes.