### PR TITLE
fix(get_task): fix tool version with cache

### DIFF
--- a/assemblyline_service_client/task_handler.py
+++ b/assemblyline_service_client/task_handler.py
@@ -418,6 +418,7 @@ class TaskHandler(ServerBase):
         if new_tool_version is not None and self.service_tool_version != new_tool_version:
             self.service_tool_version = new_tool_version
             self.session.headers.update({'service_tool_version': self.service_tool_version})
+            self.headers.update({'service_tool_version': self.service_tool_version})
 
         data = dict(task=task.as_primitives(), result=result, freshen=True)
         try:

--- a/tests/test_task_handler.py
+++ b/tests/test_task_handler.py
@@ -462,6 +462,7 @@ def test_handle_task_result():
     default_th = task_handler.TaskHandler()
     default_th.load_service_manifest()
     default_th.session = Session()
+    default_th.headers = dict()
 
     _, result_json_path = tempfile.mkstemp()
     _, extracted_path = tempfile.mkstemp()
@@ -507,6 +508,7 @@ def test_handle_task_result():
         m.post(default_th._path('task'), json={"api_response": {"success": True}})
         assert default_th.handle_task_result(result_json_path, task) is None
         assert default_th.session.headers["service_tool_version"] == "123"
+        assert default_th.headers["service_tool_version"] == "123"
 
         # It doesn't work (the first three times)
         callback_iteration = 0


### PR DESCRIPTION
Hi guys,

We've found a bug with the cache ID generation (when checking if a cache entry exists).
The service tool version is not taken in account for get cache entry, but we'll be used to write the result.
The result is that service with tool version could not use cache.

Thanks for your work.