### PR TITLE
fix service crash when request_with_retries response is None

### DIFF
--- a/assemblyline_service_client/task_handler.py
+++ b/assemblyline_service_client/task_handler.py
@@ -351,6 +351,9 @@ class TaskHandler(ServerBase):
         headers = {"Timeout": str(TASK_REQUEST_TIMEOUT)}
         self.log.info(f"Requesting a task with {TASK_REQUEST_TIMEOUT}s timeout...")
         r = self.request_with_retries('get', self._path('task'), headers=headers, timeout=TASK_REQUEST_TIMEOUT*2)
+        if r is None:
+            self.log.info("Get task failed")
+            return None
         if r['task'] is False:  # No task received
             self.log.info("No task received")
         else:  # Task received


### PR DESCRIPTION
when get_task invoke request_with_retries from service-server, if timeout, service will be crash, and then process stop，pod restart。

i met this issue in testing javadecompiler function.

service-server log:
{"@timestamp": "2025-01-06 19:45:41,340", "event": { "module": "assemblyline", "dataset": "assemblyline.dispatching.client" }, "host": { "ip": "10.244.51.99", "hostname": "service-server-79564465bc-7bhfg" }, "log": { "level": "WARNING", "logger": "assemblyline.dispatching.client" }, "process": { "pid": "10" }, "message": "[5m2ph3koTNghus87PKa2Dq/34b74ac57609efa5a423aef33aa4156dcbe06eb76141dc3d3f590302276595c7] JavaClassDecompiler could not find the specified task in its set of running tasks while processing successful results."}

javadecompiler log:
{"@timestamp": "2025-01-06 19:45:40,971", "event": { "module": "assemblyline", "dataset": "assemblyline.service.task_handler" }, "host": { "ip": "10.244.82.15", "hostname": "alsvc-javaclassdecompiler-85967f76-b247n" }, "log": { "level": "WARNING", "logger": "assemblyline.service.task_handler" }, "process": { "pid": "41" }, "message": "We've timed out on: http://service-server:5003/api/v1/task/ (HTTPConnectionPool(host='service-server', port=5003): Read timed out. (read timeout=30)) Retrying.."}
{"@timestamp": "2025-01-06 19:45:41,344", "event": { "module": "assemblyline", "dataset": "assemblyline.service.task_handler" }, "host": { "ip": "10.244.82.15", "hostname": "alsvc-javaclassdecompiler-85967f76-b247n" }, "log": { "level": "INFO", "logger": "assemblyline.service.task_handler" }, "process": { "pid": "41" }, "message": "Requesting a task with 30s timeout..."}

{"@timestamp": "2025-01-06 19:45:46,021", "event": { "module": "assemblyline", "dataset": "assemblyline.service.task_handler" }, "host": { "ip": "10.244.82.15", "hostname": "alsvc-javaclassdecompiler-85967f76-b247n" }, "log": { "level": "INFO", "logger": "assemblyline.service.task_handler" }, "process": { "pid": "41" }, "message": "Instance caught signal. Coming down..."}
{"@timestamp": "2025-01-06 19:45:46,021", "event": { "module": "assemblyline", "dataset": "assemblyline.service.task_handler" }, "host": { "ip": "10.244.82.15", "hostname": "alsvc-javaclassdecompiler-85967f76-b247n" }, "log": { "level": "INFO", "logger": "assemblyline.service.task_handler" }, "process": { "pid": "41" }, "message": "Closing task_fifo named pipes..."}
{"@timestamp": "2025-01-06 19:45:46,021", "event": { "module": "assemblyline", "dataset": "assemblyline.service.javaclassdecompiler" }, "host": { "ip": "10.244.82.15", "hostname": "alsvc-javaclassdecompiler-85967f76-b247n" }, "log": { "level": "INFO", "logger": "assemblyline.service.javaclassdecompiler" }, "process": { "pid": "40" }, "message": "Received an empty message for Task fifo. Cleaning up..."}
{"@timestamp": "2025-01-06 19:45:46,021", "event": { "module": "assemblyline", "dataset": "assemblyline.service.javaclassdecompiler" }, "host": { "ip": "10.244.82.15", "hostname": "alsvc-javaclassdecompiler-85967f76-b247n" }, "log": { "level": "INFO", "logger": "assemblyline.service.javaclassdecompiler" }, "process": { "pid": "40" }, "message": "Closing named pipes..."}
{"@timestamp": "2025-01-06 19:45:46,021", "event": { "module": "assemblyline", "dataset": "assemblyline.service.javaclassdecompiler" }, "host": { "ip": "10.244.82.15", "hostname": "alsvc-javaclassdecompiler-85967f76-b247n" }, "log": { "level": "INFO", "logger": "assemblyline.service.javaclassdecompiler" }, "process": { "pid": "40" }, "message": "Stopping service: JavaClassDecompiler"}