### PR TITLE
feat: add result POST timing and retry count logging

### DIFF
--- a/assemblyline_service_client/task_handler.py
+++ b/assemblyline_service_client/task_handler.py
@@ -215,7 +215,7 @@ class TaskHandler(ServerBase):
                     self.log.warning(f"Service server has been unreachable for the past {retry} attempts. "
                                      "Is there something wrong with it?")
             except requests.Timeout as e:  # Handles ConnectTimeout and ReadTimeout
-                self.log.warning(f"We've timed out on: {url} ({e}) Retrying..")
+                self.log.warning(f"We've timed out on: {url} ({e}) Retrying.. (attempt {retry + 1})")
                 pass
             except requests.HTTPError as e:
                 self.log.error(str(e))
@@ -465,7 +465,12 @@ class TaskHandler(ServerBase):
 
         data = dict(task=task.as_primitives(), result=result, freshen=True)
         try:
+            post_start = time.time()
             r = self.request_with_retries('post', self._path('task'), json=data, timeout=TASK_REQUEST_TIMEOUT)
+            post_elapsed = time.time() - post_start
+            if post_elapsed > 10.0:
+                self.log.warning(f"[{task.sid}] Slow result POST to service-server: {post_elapsed:.2f}s "
+                                 f"({len(result_files)} files, freshen=True)")
 
             if not r['success'] and r['missing_files']:
                 while not r['success'] and r['missing_files']:


### PR DESCRIPTION
Adds two targeted diagnostic logs to help debug service-server bottlenecks under high load:

1. **Slow result POST warning**: Logs when the result POST to service-server takes >10s, including file count
2. **Retry attempt count**: Adds attempt number to timeout warnings for easier diagnosis of escalating connectivity issues

These only fire during degradation — zero noise during normal operation.

**Related PR:** https://github.com/CybercentreCanada/assemblyline-base/pull/2136 (readonly_storage support)